### PR TITLE
Fixed "error: ‘CV_RGB2BGR’ was not declared in this scope; did you mean ‘CV_RGB’?"

### DIFF
--- a/examples/liveview.cpp
+++ b/examples/liveview.cpp
@@ -132,7 +132,7 @@ main(int argc, const char *argv[])
 	    k4w2_decoder_fetch(decoder[COLOR], slot, rgb8U3.data, 1920*1080*3);
 
 	    if (is_rgb_colorspace)
-		cv::cvtColor(rgb8U3, rgb8U3, CV_RGB2BGR);
+		cv::cvtColor(rgb8U3, rgb8U3, cv::COLOR_RGB2BGR);
 
 	    cv::resize(rgb8U3, resized8U3, cv::Size(), 1, 1);
 

--- a/examples/opencv.cpp
+++ b/examples/opencv.cpp
@@ -117,7 +117,7 @@ main(int argc, const char *argv[])
 	    cv::resize(rgb8U3, resized8U3, cv::Size(), 0.5, 0.5);
 
 	    if (is_rgb_colorspace)
-		cv::cvtColor(resized8U3, resized8U3, CV_RGB2BGR);
+		cv::cvtColor(resized8U3, resized8U3, cv::COLOR_RGB2BGR);
 	    cv::imshow("rgb", resized8U3);
 
 	    last_ptr[COLOR] = NULL;


### PR DESCRIPTION
I fixed the error by replacing `cv::cvtColor(rgb8U3, rgb8U3, CV_RGB2BGR);` with `cv::cvtColor(rgb8U3, rgb8U3, cv::COLOR_RGB2BGR);` and `cv::cvtColor(resized8U3, resized8U3, CV_RGB2BGR);` with `cv::cvtColor(resized8U3, resized8U3, cv::COLOR_RGB2BGR);`